### PR TITLE
Remove Scala 2.12 from build

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: ["2.13.3", "2.12.14"]
+        scala: ["2.13.6"]
 
     runs-on: ubuntu-latest
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val commonScalacOptions = Seq(
 
 lazy val basicSettings =
   Seq(
-    crossScalaVersions := Seq("2.13.6", "2.12.14"),
+    crossScalaVersions := Seq("2.13.6"),
     scalaVersion := crossScalaVersions.value.head,
     scalacOptions := commonScalacOptions
   )


### PR DESCRIPTION
It prevents us from upgrading scala-graph to 1.13.2 which we need for
ScalaJS 1.x